### PR TITLE
Fix id with non imprimible characters

### DIFF
--- a/internal/provider/data_source_dotenv.go
+++ b/internal/provider/data_source_dotenv.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"crypto/sha1"
+	"encoding/base64"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -61,6 +62,6 @@ func dataSourceDotEnvRead(ctx context.Context, d *schema.ResourceData, meta inte
 	// generate ID as sha of the contents
 	h := sha1.New()
 	h.Write([]byte(contents))
-	d.SetId(string(h.Sum(nil)))
+	d.SetId(string(base64.StdEncoding.EncodeToString(h.Sum(nil))))
 	return nil
 }


### PR DESCRIPTION
Because the id of the resources were computed using a sha1 hash of the contents of the .env file, it could contain non imprimible characters.

This commit attempts to fix the problem described above. Instead of using directly the sha1 hash, we can encode it in base64 and be sure it only contains safe imprimible characters.

Hopefully fixes #49 .

Thanks!!